### PR TITLE
Improve canonical URL and full navigation update

### DIFF
--- a/lib/Locale.js
+++ b/lib/Locale.js
@@ -83,43 +83,63 @@ class Locale {
     // Create a navigation element. The page is the base URL to link to and the
     // query is the query string to append the language to. The query string
     // may have other parameters as long as the final part is the query string
-    // key (which may be empty) without the key-value separator.
+    // key (which may be empty) without the key-value separator, but it is also
+    // possible to provide the parameters in the page. Anchor portions should be
+    // provided in the hash, starting with a hash sign.
     generateNavigation(nav, page='', query='', linkActive=false, classes='', hash='') {
         if (!(nav instanceof d3.selection)) {
             nav = d3.select(nav);
         }
-        const item = nav.append('ul')
+        let url = null;
+        let separator = '?';
+        try {
+            url = new URL(page);
+            url.searchParams.delete(query);
+            url.hash = '';
+            page = url.toString();
+            separator = url.search === '' ? '?' : '&';
+        }
+        catch (error) {
+            separator = page.includes('?') ? '&' : '?';
+        }
+
+        const updateItems = nav.selectAll('ul')
+            .data(['visualization-ui-locale-nav'])
+            .join('ul')
             .selectAll('li')
-            .data(Object.keys(this.specs))
-            .enter()
+            .data(Object.keys(this.specs));
+        const newItems = updateItems.enter()
             .append('li');
-        const link = item.append('a')
-            .call(this.updateNavigationLinks, page, query, hash)
+        newItems.append('a');
+        const items = updateItems.merge(newItems);
+        const links = items.selectAll('a')
+            .call(this.updateNavigationLinks, page, query, hash, separator)
             .attr('hreflang', d => d)
             .text(d => this.specs[d].language);
-        const active = linkActive === 'link' ? link : item;
+        const active = linkActive === 'link' ? links : items;
         active.classed('is-active', d => this.specs[d] == this.selectedLocale)
             .classed(classes, true);
 
-        // Update HEAD
-        if (page != '') {
+        // Update HEAD with canonical/alternate URLs
+        if (url !== null) {
             const head = d3.select('head');
-            head.selectAll('link[rel=canonical]').data([''])
+            head.selectAll('link[rel=canonical]')
+                .data(['visualization-ui-locale-canonical'])
                 .join('link')
                 .attr('rel', 'canonical')
-                .attr('href', page);
+                .attr('href', url);
             head.selectAll('link[rel=alternate][hreflang]')
                 .data(Object.keys(this.specs))
                 .join('link')
                 .attr('rel', 'alternate')
                 .attr('hreflang', d => d)
-                .call(this.updateNavigationLinks, page, query);
+                .call(this.updateNavigationLinks, url, query, '', separator);
         }
     }
 
-    updateNavigationLinks(links, page='', query='', hash='') {
+    updateNavigationLinks(links, page='', query='', hash='', separator='?') {
         links.attr('href',
-            d => `${page}?${query ? `${query}=` : ''}${d}${hash}`
+            d => `${page}${separator}${query ? `${query}=` : ''}${d}${hash}`
         );
     }
 

--- a/lib/Locale.js
+++ b/lib/Locale.js
@@ -86,12 +86,12 @@ class Locale {
     // key (which may be empty) without the key-value separator, but it is also
     // possible to provide the parameters in the page. Anchor portions should be
     // provided in the hash, starting with a hash sign.
-    generateNavigation(nav, page='', query='', linkActive=false, classes='', hash='') {
+    generateNavigation(nav, page='', query='', linkActive='item', classes='', hash='') {
         if (!(nav instanceof d3.selection)) {
             nav = d3.select(nav);
         }
         let url = null;
-        let separator = '?';
+        let separator = null;
         try {
             url = new URL(page);
             url.searchParams.delete(query);
@@ -139,7 +139,7 @@ class Locale {
 
     updateNavigationLinks(links, page='', query='', hash='', separator='?') {
         links.attr('href',
-            d => `${page}${separator}${query ? `${query}=` : ''}${d}${hash}`
+            d => `${page}${separator}${query}${query ? '=' : ''}${d}${hash}`
         );
     }
 


### PR DESCRIPTION
- The URL may now contain a query string, from which the language query parameter is removed if it was there, and hashes are ignored (but only if the URL was absolute, so it is best not to provide at all)
- The proper query string separator is used for the language query parameter, effectively allowing the URL/page to contain a query string instead of stuffing it all in the query parameter
- Do not add another hash to the canonical URL
- When the language navigation is generated in the same container, instead update the existing items (but this does not override active and other classes if they were set on links before and items now or the other way around)
- Separate tests in more units and test different cases more thoroughly