### PR TITLE
Navbar: Optionally obtain canonical base URL from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ import {Locale, Navbar} from '@gros/visualization-ui';
 const locales = new Locale();
 const nav = new Navbar({
     "container": ".navbar", // Navbar container
+    "base_url": "https://test.example", // Canonical URL of "base" website
     "languages": "#languages", // Selector of a menu in the structure
-    "language_page": "https://test.example/index.html", // Canonical URL
-    "language_query": "lang",
+    "language_page": "index.html", // Canonical (may be relative to base_url)
+    "language_query": "lang", // Query parameter to add for language switch
     "my_url": "https://example.com" // Referenced from a link with "config" key
 }, locales);
 nav.fill(structure);

--- a/lib/Navbar.js
+++ b/lib/Navbar.js
@@ -27,6 +27,7 @@ const defaultConfiguration = {
     languages: "",
     language_page: "",
     language_query: "lang",
+    base_url: "",
     window: window,
     document: document
 };
@@ -144,7 +145,7 @@ class Navbar {
         if (this.config.languages) {
             const languages = selection.select(this.config.languages);
             const canonicalUrl = new URL(this.config.language_page,
-                this.config.document.location
+                this.config.base_url || this.config.document.location
             );
             canonicalUrl.searchParams.delete(this.config.language_query);
             canonicalUrl.hash = '';


### PR DESCRIPTION
This configuration might be used to provide a more stable source for canonical URLs than the document location in the fallback chain, and lets the `language_page` configuration be relative to this URL instead.